### PR TITLE
filter empty blocks + hide network utilization info

### DIFF
--- a/ui/blocks/BlocksList.tsx
+++ b/ui/blocks/BlocksList.tsx
@@ -16,7 +16,7 @@ const BlocksList = ({ data, isLoading, page }: Props) => {
   return (
     <Box>
       <AnimatePresence initial={ false }>
-        { data.map((item, index) => (
+        { data.filter((block) => block.tx_count > 0).map((item, index) => (
           <BlocksListItem
             key={ item.height + (isLoading ? String(index) : '') }
             data={ item }

--- a/ui/blocks/BlocksTabSlot.tsx
+++ b/ui/blocks/BlocksTabSlot.tsx
@@ -1,11 +1,12 @@
-import { Flex, Box, Text, Skeleton } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
+// import { Flex, Box, Text, Skeleton } from '@chakra-ui/react';
 import React from 'react';
 
 import type { PaginationParams } from 'ui/shared/pagination/types';
 
-import useApiQuery from 'lib/api/useApiQuery';
-import { nbsp } from 'lib/html-entities';
-import { HOMEPAGE_STATS } from 'stubs/stats';
+// import useApiQuery from 'lib/api/useApiQuery';
+// import { nbsp } from 'lib/html-entities';
+// import { HOMEPAGE_STATS } from 'stubs/stats';
 import Pagination from 'ui/shared/pagination/Pagination';
 
 interface Props {
@@ -13,15 +14,15 @@ interface Props {
 }
 
 const BlocksTabSlot = ({ pagination }: Props) => {
-  const statsQuery = useApiQuery('stats', {
-    queryOptions: {
-      placeholderData: HOMEPAGE_STATS,
-    },
-  });
+  // const statsQuery = useApiQuery('stats', {
+  //   queryOptions: {
+  //     placeholderData: HOMEPAGE_STATS,
+  //   },
+  // });
 
   return (
     <Flex alignItems="center" columnGap={ 8 } display={{ base: 'none', lg: 'flex' }}>
-      { statsQuery.data?.network_utilization_percentage !== undefined && (
+      { /* { statsQuery.data?.network_utilization_percentage !== undefined && (
         <Box>
           <Text as="span" fontSize="sm">
               Network utilization (last 50 blocks):{ nbsp }
@@ -30,7 +31,7 @@ const BlocksTabSlot = ({ pagination }: Props) => {
             <span>{ statsQuery.data.network_utilization_percentage.toFixed(2) }%</span>
           </Skeleton>
         </Box>
-      ) }
+      ) } */ }
       <Pagination my={ 1 } { ...pagination }/>
     </Flex>
   );

--- a/ui/blocks/BlocksTable.tsx
+++ b/ui/blocks/BlocksTable.tsx
@@ -66,7 +66,7 @@ const BlocksTable = ({ data, isLoading, top, page, showSocketInfo, socketInfoNum
             />
           ) }
           <AnimatePresence initial={ false }>
-            { data.map((item, index) => (
+            { data.filter((block) => block.tx_count > 0).map((item, index) => (
               <BlocksTableItem
                 key={ item.height + (isLoading ? `${ index }_${ page }` : '') }
                 data={ item }


### PR DESCRIPTION
## Description and Related Issue(s)
Had this requirement: let's not show / flash empty blocks. and hide "network utilization".

*[Provide a brief description of the changes or enhancements introduced by this pull request and explain motivation behind them. Cite any related issue(s) or bug(s) that it addresses using the [format](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/) `Fixes #123` or `Resolves #456`.]*

### Proposed Changes
*[Specify the changes or additions made in this pull request. Please mention if any changes were made to the ENV variables]*

### Breaking or Incompatible Changes
*[Describe any breaking or incompatible changes introduced by this pull request. Specify how users might need to modify their code or configurations to accommodate these changes.]*

### Additional Information
*[Include any additional information, context, or screenshots that may be helpful for reviewers.]*

## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable, I have updated the list of environment variables in the [documentation](ENVS.md) and  made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
